### PR TITLE
Use platform-independent print formatting

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1,7 +1,5 @@
 #include "db_impl.h"
 
-#include <inttypes.h>
-
 #include <cassert>
 #include <condition_variable>
 #include <cstdlib>
@@ -158,7 +156,7 @@ Status DBImpl::InitializeNewDB() {
 
     model_->PreallocateAndInitialize(buf_mgr_, records,
                                      options_.key_hints.records_per_page());
-    Logger::Log("Created new %s. Total size: %" PRIu64 " bytes. Indexed pages: %" PRIu64,
+    Logger::Log("Created new %s. Total size: %zu bytes. Indexed pages: %zu",
                 options_.use_alex ? "ALEX" : "BTree", model_->GetSizeBytes(),
                 model_->GetNumPages());
 
@@ -198,7 +196,7 @@ Status DBImpl::InitializeExistingDB() {
   }
 
   model_->ScanFilesAndInitialize(buf_mgr_);
-  Logger::Log("Rebuilt %s. Total size: %" PRIu64 " bytes. Indexed pages: %" PRIu64,
+  Logger::Log("Rebuilt %s. Total size: %zu bytes. Indexed pages: %zu",
               options_.use_alex ? "ALEX" : "BTree", model_->GetSizeBytes(),
               model_->GetNumPages());
 
@@ -530,7 +528,7 @@ void DBImpl::ScheduleMemTableFlush(std::unique_lock<std::mutex>& lock,
              bufmgr_miss_latency_ns.count() /
              memtable_fill_duration_ns.count());
 
-    Logger::Log("Autotuned deferred I/O batch size: %" PRIu64 " bytes",
+    Logger::Log("Autotuned deferred I/O batch size: %zu bytes",
                 foptions.deferred_io_batch_size);
   }
 
@@ -615,12 +613,12 @@ void DBImpl::ScheduleMemTableFlush(std::unique_lock<std::mutex>& lock,
     assert(mem_budget_memtables_ < mem_budget_);
 
     // Log the tuned parameters.
-    Logger::Log("Buffer pool bytes wanted: %" PRIu64, buffer_pool_bytes_wanted);
+    Logger::Log("Buffer pool bytes wanted: %zu", buffer_pool_bytes_wanted);
     Logger::Log("Buffer pool pages added: %zd", buffer_pool_pages_added);
     Logger::Log(
-        "Memtable memory budget: %" PRIu64,
+        "Memtable memory budget: %zu",
         mem_budget_memtables_.load(std::memory_order::memory_order_relaxed));
-    Logger::Log("Buffer pool pages: %" PRIu64, buf_mgr_->GetNumPages());
+    Logger::Log("Buffer pool pages: %zu", buf_mgr_->GetNumPages());
   }
 
   // Mark the active memtable as immutable and create a new active memtable.

--- a/db/db_impl_reorg.cc
+++ b/db/db_impl_reorg.cc
@@ -57,7 +57,7 @@ Status DBImpl::ReorganizeOverflowChain(PhysicalPageId page_id,
 
     Logger::Log(
         "Chain is too long to be reorganized without violating the maximum "
-        "reorganization fanout. Chain length: %" PRIu64,
+        "reorganization fanout. Chain length: %zu",
         chain->size());
 
     return Status::InvalidArgument(
@@ -195,8 +195,8 @@ Status DBImpl::ReorganizeOverflowChain(PhysicalPageId page_id,
     upper = __builtin_bswap64(upper);
     Logger::Log(
         "WARNING: Reorganization produced fewer pages than the length of the "
-        "original chain. Pages will be leaked on disk.\nOld Pages: %" PRIu64
-        ", New Pages: %" PRIu64 "\nChain Boundary Lower: %" PRIu64
+        "original chain. Pages will be leaked on disk.\nOld Pages: %zu"
+        ", New Pages: %zu\nChain Boundary Lower: %" PRIu64
         ", Chain Boundary Upper: %" PRIu64,
         old_num_pages, new_num_pages, lower, upper);
   }


### PR DESCRIPTION
Using `%llu` generated compiler warnings for some systems, since the definition of `size_t` and the correspondence of `uint64_t` to integer types is system-dependent.

Updated the code to use the recommended `%zu` for `size_t` and the macro `PRIu64` for `uint64_t`.