### PR TITLE
Add uniform YCSB variants

### DIFF
--- a/scripts/e2e_custom/ycsb/workloads/un_a.yml
+++ b/scripts/e2e_custom/ycsb/workloads/un_a.yml
@@ -1,0 +1,19 @@
+record_size_bytes: 64
+
+load:
+  num_records: 20000000
+  distribution:
+    type: uniform
+    range_min: 0
+    range_max: 2000000000
+
+run:
+- num_requests: 10000000
+  read:
+    proportion_pct: 50
+    distribution:
+      type: uniform
+  update:
+    proportion_pct: 50
+    distribution:
+      type: uniform

--- a/scripts/e2e_custom/ycsb/workloads/un_b.yml
+++ b/scripts/e2e_custom/ycsb/workloads/un_b.yml
@@ -1,0 +1,19 @@
+record_size_bytes: 64
+
+load:
+  num_records: 20000000
+  distribution:
+    type: uniform
+    range_min: 0
+    range_max: 2000000000
+
+run:
+- num_requests: 10000000
+  read:
+    proportion_pct: 95
+    distribution:
+      type: uniform
+  update:
+    proportion_pct: 5
+    distribution:
+      type: uniform

--- a/scripts/e2e_custom/ycsb/workloads/un_c.yml
+++ b/scripts/e2e_custom/ycsb/workloads/un_c.yml
@@ -1,0 +1,15 @@
+record_size_bytes: 64
+
+load:
+  num_records: 20000000
+  distribution:
+    type: uniform
+    range_min: 0
+    range_max: 2000000000
+
+run:
+- num_requests: 10000000
+  read:
+    proportion_pct: 100
+    distribution:
+      type: uniform

--- a/scripts/e2e_custom/ycsb/workloads/un_d.yml
+++ b/scripts/e2e_custom/ycsb/workloads/un_d.yml
@@ -1,0 +1,21 @@
+record_size_bytes: 64
+
+load:
+  num_records: 20000000
+  distribution:
+    type: uniform
+    range_min: 0
+    range_max: 2000000000
+
+run:
+- num_requests: 10000000
+  read:
+    proportion_pct: 95
+    distribution:
+      type: uniform
+  insert:
+    proportion_pct: 5
+    distribution:
+      type: uniform
+      range_min: 0
+      range_max: 2000000000

--- a/scripts/e2e_custom/ycsb/workloads/un_e.yml
+++ b/scripts/e2e_custom/ycsb/workloads/un_e.yml
@@ -1,0 +1,22 @@
+record_size_bytes: 64
+
+load:
+  num_records: 20000000
+  distribution:
+    type: uniform
+    range_min: 0
+    range_max: 2000000000
+
+run:
+- num_requests: 100000
+  scan:
+    proportion_pct: 95
+    max_length: 100
+    distribution:
+      type: uniform
+  insert:
+    proportion_pct: 5
+    distribution:
+      type: uniform
+      range_min: 0
+      range_max: 2000000000

--- a/scripts/e2e_custom/ycsb/workloads/un_f.yml
+++ b/scripts/e2e_custom/ycsb/workloads/un_f.yml
@@ -1,0 +1,19 @@
+record_size_bytes: 64
+
+load:
+  num_records: 20000000
+  distribution:
+    type: uniform
+    range_min: 0
+    range_max: 2000000000
+
+run:
+- num_requests: 10000000
+  read:
+    proportion_pct: 50
+    distribution:
+      type: uniform
+  readmodifywrite:
+    proportion_pct: 50
+    distribution:
+      type: uniform


### PR DESCRIPTION
This PR adds 6 additional workloads inspired by YCSB A-F but replacing all request distributions with `uniform`.

These are useful in evaluating the performance of skew-sensitive aspects of our design (e.g. buffer pool effectiveness).