### PR TITLE
Update R/W sweep experiments and scripts

### DIFF
--- a/scripts/rw_sweep/COND
+++ b/scripts/rw_sweep/COND
@@ -1,65 +1,177 @@
 from itertools import product
 
 DB = ["llsm", "rocksdb"]
-WRITE_SPLITS = list(range(0, 110, 10))
+
+# 0, 20, 40, ..., 100
+WRITE_SPLITS = list(range(0, 110, 20))
+
 COMMON_OPTIONS = {
-  "bg_threads": 16,
-  "threads": 1,
+  "bg_threads": 4,
+  "threads": 16,
   "bypass_wal": True,
-  "llsm_page_fill_pct": 50,
+  "llsm_page_fill_pct": 75,
   "use_direct_io": True,
   "latency_sample_period": 10,
-  "gen_num_records": 20000000,
-  "gen_num_requests": 10000000,
+  "rdb_bloom_bits": 10,
+  "gen_scan_read_percent": 50,  # 50% of the reads are scans
+  "use_alex": False,
 }
 
-BUFFER_SIZES = [
-  (64, 280),  # (memtable_size_mib, cache_size_mib) - Total 408 MiB (~33% of the dataset size)
-  (172, 64),
+CONFIGS = [
+  {
+    "gen_record_size_bytes": 64,
+    "gen_num_records": 20000000,   # 20 M
+    "gen_num_requests": 20000000,  # 20 M
+  },
+  {
+    "gen_record_size_bytes": 1024,
+    "gen_num_records": 10000000,   # 10 M
+    "gen_num_requests": 10000000,  # 10 M
+  },
 ]
+
+MEMORY_CONFIG = {
+  64: {
+    "memtable_size_mib": 64,
+    "cache_size_mib": 280,         # 408 MiB in total ~33% of the dataset
+  },
+  1024: {
+    "memtable_size_mib": 510,
+    "cache_size_mib": 2235,        # 3255 MiB in total ~33% of the dataset
+  },
+}
+
 DISTRIBUTIONS = ["zipfian", "uniform"]
 
+def memory_usage(db, record_size_bytes):
+  mem = MEMORY_CONFIG[record_size_bytes]
+  if db == "llsm":
+    # This experiment is meant to be run without LLSM's memtable (to mimic a
+    # disk-based B+Tree).
+    return {
+      "cache_size_mib": mem["cache_size_mib"] + (2 * mem["memtable_size_mib"]),
+    }
+  else:
+    return mem
+
+
+run_command(
+  name="plot-zipfian-64",
+  run="python3 plot_e2e.py",
+  options={
+    "distribution": "zipfian",
+    "record_size_bytes": 64,
+    "y_min": 0,
+    "y_max": 500,
+  },
+  deps=[":combine"],
+)
+
+run_command(
+  name="combine",
+  run="python3 combine_raw.py",
+  deps=[":rw_sweep"],
+)
+
+run_command(
+  name="combine-zipfian",
+  run="python3 combine_raw.py",
+  deps=[":rw_sweep-zipfian"],
+)
+
+run_command(
+  name="combine-uniform",
+  run="python3 combine_raw.py",
+  deps=[":rw_sweep-uniform"],
+)
+
+# All `rw_sweep` experiments with zipfian distributed requests.
+# This is used for running a subset of the experiments.
+combine(
+  name="rw_sweep-zipfian",
+  deps=[
+    ":rw_sweep-{db}-{rsb}-{write_split}-zipfian".format(
+      db=db,
+      rsb=config["gen_record_size_bytes"],
+      write_split=write_split,
+    )
+    for db, config, write_split in product(DB, CONFIGS, WRITE_SPLITS)
+  ],
+)
+
+# All `rw_sweep` experiments with uniformly distributed requests.
+# This is used for running a subset of the experiments.
+combine(
+  name="rw_sweep-uniform",
+  deps=[
+    ":rw_sweep-{db}-{rsb}-{write_split}-uniform".format(
+      db=db,
+      rsb=config["gen_record_size_bytes"],
+      write_split=write_split,
+    )
+    for db, config, write_split in product(DB, CONFIGS, WRITE_SPLITS)
+  ],
+)
+
 run_experiment_group(
-  name="64B",
-  run="./run.sh rw_sweep-64B",
+  name="rw_sweep",
+  run="./run.sh",
   experiments=[
     ExperimentInstance(
-      name="64B-{}-{}-mem-{}-cache-{}-{}"
-        .format(db, write_split, memtable_mib, cache_mib, dist),
+      name="rw_sweep-{db}-{rsb}-{write_split}-{dist}".format(
+        db=db,
+        rsb=config["gen_record_size_bytes"],
+        write_split=write_split,
+        dist=dist,
+      ),
       options={
         **COMMON_OPTIONS,
+        **config,
+        **memory_usage(db, config["gen_record_size_bytes"]),
         "db": db,
-        "memtable_size_mib": memtable_mib,
-        "cache_size_mib": cache_mib,
-        "gen_record_size_bytes": 64,
         "gen_update_percent": write_split,
         "gen_distribution": dist,
+        "checkpoint_name": "rw_sweep-{db}-{rsb}".format(
+          db=db,
+          rsb=config["gen_record_size_bytes"],
+        ),
       },
     )
-    for db, write_split, (memtable_mib, cache_mib), dist in \
-      product(DB, WRITE_SPLITS, BUFFER_SIZES, DISTRIBUTIONS)
+    for config, db, write_split, dist in product(
+      CONFIGS,
+      DB,
+      WRITE_SPLITS,
+      DISTRIBUTIONS,
+    )
   ],
-  deps=[":preload-64B"],
+  deps=[":preload"],
 )
 
-run_command(
-  name="preload-64B",
-  run="".join([
-    "./preload.sh rw_sweep-64B --gen_for_preload"
-    " --gen_num_records=", str(COMMON_OPTIONS["gen_num_records"]),
-    " --gen_num_requests=", str(COMMON_OPTIONS["gen_num_requests"]),
-    " --gen_record_size_bytes=64",
-  ]),
+group(
+  name="preload",
+  deps=[
+    ":preload-{db}-{rsb}".format(
+      db=db,
+      rsb=config["gen_record_size_bytes"],
+    )
+    for db, config in product(DB, CONFIGS)
+  ],
 )
 
-run_command(
-  name="combine-64B",
-  run="python3 combine_raw.py",
-  deps=[":64B"],
-)
-
-run_command(
-  name="plot-64B",
-  run="python3 plot_e2e.py",
-  deps=[":combine-64B"],
-)
+for db, config in product(DB, CONFIGS):
+  run_command(
+    name="preload-{db}-{rsb}".format(
+      db=db,
+      rsb=config["gen_record_size_bytes"],
+    ),
+    run="./preload.sh",
+    args=["--gen_for_preload"],
+    options={
+      **config,
+      "db": db,
+      "checkpoint_name": "rw_sweep-{db}-{rsb}".format(
+        db=db,
+        rsb=config["gen_record_size_bytes"],
+      ),
+    },
+  )

--- a/scripts/rw_sweep/generate_workload.py
+++ b/scripts/rw_sweep/generate_workload.py
@@ -1,4 +1,5 @@
 import argparse
+import math
 import conductor.lib as cond
 
 
@@ -31,6 +32,10 @@ run:
   read:
     proportion_pct: {read_pct}
 {distribution}
+  scan:
+    proportion_pct: {scan_pct}
+    max_length: 100
+{distribution}
   update:
     proportion_pct: {update_pct}
 {distribution}
@@ -53,6 +58,14 @@ def main():
     parser.add_argument("--gen_num_requests", type=int, required=True)
     parser.add_argument("--gen_distribution", choices=["zipfian", "uniform"])
     parser.add_argument("--gen_update_percent", type=int)
+    # What percent of the reads should be scans? This is applied to the
+    # workload's read percentage.
+    #
+    # For example, suppose 10% of the workload should consist of reads and this
+    # argument is set to 5%. Then 1% of the workload will consist of scans
+    # whereas the other 9% will be point reads (we round fractional percentages
+    # up to the nearest percent).
+    parser.add_argument("--gen_scan_read_percent", type=int)
     parser.add_argument("--gen_for_preload", action="store_true")
     args, unknown = parser.parse_known_args()
 
@@ -66,9 +79,15 @@ def main():
             [load_section, PRELOAD_RUN.format(num_requests=args.gen_num_requests // 2)]
         )
     else:
+        total_read_pct = 100 - args.gen_update_percent
+        scan_pct = math.ceil(total_read_pct * (args.gen_scan_read_percent / 100))
+        read_pct = total_read_pct - scan_pct
+        assert read_pct + scan_pct + args.gen_update_percent == 100
+
         run_section = RUN_SECTION.format(
             num_requests=args.gen_num_requests,
-            read_pct=100 - args.gen_update_percent,
+            read_pct=read_pct,
+            scan_pct=scan_pct,
             update_pct=args.gen_update_percent,
             distribution=ZIPFIAN if args.gen_distribution == "zipfian" else UNIFORM,
         )

--- a/scripts/rw_sweep/plot_e2e.py
+++ b/scripts/rw_sweep/plot_e2e.py
@@ -1,3 +1,5 @@
+import argparse
+
 import conductor.lib as cond
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -12,51 +14,91 @@ DB_FORMAT = {
 }
 
 
-def plot_e2e(df, distribution, show_legend=False):
+def plot_e2e(
+    df,
+    distribution,
+    record_size,
+    show_legend=False,
+    exclude_100=False,
+    title=None,
+    ylim=None,
+):
     fig, ax = plt.subplots(
         figsize=(6.65, 4),
         tight_layout=True,
         frameon=False,
     )
     dbs = df["db"].unique()
-    # (memtable_mib, cache_mib)
-    configs = [(64, 3200), (3200, 64)]
     for db in dbs:
-        for (memtable_mib, cache_mib) in configs:
-            data = df[(df["db"] == db) &
-                      (df["memtable_mib"] == memtable_mib) &
-                      (df["cache_mib"] == cache_mib) &
-                      (df["dist"] == distribution) &
-                      (df["update_pct"] != 100)]
-            ax.plot(
-                data["update_pct"],
-                data["mops_per_s"] * 1000,
-                marker="o",
-                markersize=5,
-                label="{} W {} / C {}"
-                    .format(DB_FORMAT[db], memtable_mib, cache_mib),
-            )
+        df_filter = (
+            (df["db"] == db)
+            & (df["dist"] == distribution)
+            & (df["record_size_bytes"] == record_size)
+        )
+        if exclude_100:
+            df_filter &= df["update_pct"] != 100
+
+        data = df[df_filter]
+        ax.plot(
+            data["update_pct"],
+            data["krequests_per_s"],
+            marker="o",
+            markersize=5,
+            label=DB_FORMAT[db],
+        )
     if show_legend:
         ax.legend(
             edgecolor="#000000",
             fancybox=False,
             framealpha=1,
         )
-    ax.set_ylabel("Throughput (kops/s)")
-    ax.set_xlabel("Write Percentage (%)")
-    #ax.set_ylim(0, 150)
+    ax.set_ylabel("Throughput (kreq/s)")
+    ax.set_xlabel("Update Percentage (%)")
+    if ylim is not None:
+        ax.set_ylim(ylim)
+    if title is not None:
+        ax.set_title(title)
+
+    if not exclude_100:
+        # Print the value at 100.
+        rel = df[
+            (df["db"] == "rocksdb")
+            & (df["dist"] == distribution)
+            & (df["record_size_bytes"] == record_size)
+            & (df["update_pct"] == 100)
+        ]
+        max_val = rel["krequests_per_s"].iloc[0]
+        fig.text(0.82, 0.94, "{:.2f}".format(max_val))
+
     return fig, ax
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--distribution", type=str, required=True)
+    parser.add_argument("--record_size_bytes", type=int, required=True)
+    parser.add_argument("--y_min", type=int)
+    parser.add_argument("--y_max", type=int)
+    args = parser.parse_args()
+
+    ylim = None
+    if args.y_min is not None and args.y_max is not None:
+        ylim = (args.y_min, args.y_max)
+
     out_dir = cond.get_output_path()
     df = pd.read_csv(cond.get_deps_paths()[0] / "all_results.csv")
-    for distribution in DISTRIBUTIONS:
-        fig, ax = plot_e2e(
-            df,
-            distribution,
-            show_legend=(distribution == DISTRIBUTIONS[0]))
-        fig.savefig(out_dir / "e2e-{}.pdf".format(distribution), format="pdf")
+    fig, _ = plot_e2e(
+        df,
+        distribution=args.distribution,
+        record_size=args.record_size_bytes,
+        show_legend=True,
+        ylim=ylim,
+    )
+    fig.savefig(
+        out_dir
+        / "rw_sweep-{}-{}.pdf".format(args.distribution, args.record_size_bytes),
+        format="pdf",
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/rw_sweep/preload.sh
+++ b/scripts/rw_sweep/preload.sh
@@ -5,58 +5,73 @@ script_loc=$(cd $(dirname $0) && pwd -P)
 cd $script_loc
 source ../experiment_config.sh
 
-if [ -z $1 ]; then
-  >&2 echo "Usage: $0 <checkpoint name> [other args passed to run_custom]"
+# Evaluates any environment variables in this script's arguments. This script
+# should only be run on trusted input.
+orig_args=($@)
+all_args=()
+for val in "${orig_args[@]}"; do
+  phys_arg=$(eval "echo $val")
+
+  # Extract the database type (e.g., llsm, rocksdb, leanstore)
+  if [[ $phys_arg =~ --db=.+ ]]; then
+    db_type=${phys_arg:5}
+  fi
+
+  # Extract the checkpoint name, which shouldn't be passed as an argument further.
+  # Add anything else to args.
+  if [[ $phys_arg =~ --checkpoint_name=.+ ]]; then
+    checkpoint_name=${phys_arg:18}
+  else
+    all_args+=($phys_arg)
+  fi
+done
+
+if [[ -z $db_type || -z $checkpoint_name ]]; then
+  echo >&2 "Usage: $0 --checkpoint_name=<checkpoint name> --db=<all|rocksdb|llsm> [other args passed to run_custom]"
   exit 1
 fi
-
-checkpoint_name=$1
-shift 1
 
 full_checkpoint_path=$DB_CHECKPOINT_PATH/$checkpoint_name
 
 # Check if the checkpoint already exists. If so, we do not need to rerun.
 if [ -d "$full_checkpoint_path" ]; then
-  >&2 echo "Checkpoint $checkpoint_name already exists. No need to recreate."
+  echo >&2 "Checkpoint $checkpoint_name already exists. No need to recreate."
   exit 0
 fi
-
-# Evaluates any environment variables in this script's arguments. This script
-# should only be run on trusted input.
-orig_args=$@
-all_args=()
-for val in "${orig_args[@]}"; do
-  all_args+=$(eval "echo $val")
-done
 
 mkdir -p $DB_CHECKPOINT_PATH
 
 # Generates the workload configuration and filters out unrelated arguments.
-args=$(python3 generate_workload.py $all_args)
+args=$(python3 generate_workload.py ${all_args[@]})
 
-# RocksDB - Important to use 64 MiB memtables to ensure the emitted sstables
-#           are small too.
-../../build/bench/run_custom \
-  --db=rocksdb \
-  --db_path=$full_checkpoint_path \
-  --bg_threads=16 \
-  --bypass_wal=true \
-  --memtable_size_mib=64 \
-  --workload_config=$COND_OUT/workload.yml \
-  --use_direct_io=true \
-  --seed=$SEED \
-  --verbose \
-  $args
+if [ $db_type == "rocksdb" ] || [ $db_type == "all" ]; then
+  # RocksDB - Important to use 64 MiB memtables to ensure the emitted sstables
+  #           are small too.
+  ../../build/bench/run_custom \
+    --db=rocksdb \
+    --db_path=$full_checkpoint_path \
+    --bg_threads=16 \
+    --bypass_wal=true \
+    --memtable_size_mib=64 \
+    --workload_config=$COND_OUT/workload.yml \
+    --use_direct_io=true \
+    --seed=$SEED \
+    --verbose \
+    --rdb_bloom_bits=10 \
+    ${args[@]}
+fi
 
-# LLSM - Use a larger memtable to help the load run faster.
-../../build/bench/run_custom \
-  --db=llsm \
-  --db_path=$full_checkpoint_path \
-  --bg_threads=16 \
-  --bypass_wal=true \
-  --llsm_page_fill_pct=50 \
-  --memtable_size_mib=2048 \
-  --workload_config=$COND_OUT/workload.yml \
-  --seed=$SEED \
-  --verbose \
-  $args
+if [ $db_type == "llsm" ] || [ $db_type == "all" ]; then
+  # LLSM - Use a larger memtable to help the load run faster.
+  ../../build/bench/run_custom \
+    --db=llsm \
+    --db_path=$full_checkpoint_path \
+    --bg_threads=16 \
+    --bypass_wal=true \
+    --llsm_page_fill_pct=70 \
+    --workload_config=$COND_OUT/workload.yml \
+    --seed=$SEED \
+    --verbose \
+    --use_alex=false \
+    ${args[@]}
+fi

--- a/scripts/rw_sweep/run.sh
+++ b/scripts/rw_sweep/run.sh
@@ -5,46 +5,89 @@ script_loc=$(cd $(dirname $0) && pwd -P)
 cd $script_loc
 source ../experiment_config.sh
 
-if [ -z $1 ]; then
-  >&2 echo "Usage: $0 <checkpoint name> [other args passed to run_custom]"
+# Evaluates any environment variables in this script's arguments. This script
+# should only be run on trusted input.
+orig_args=($@)
+all_args=()
+for val in "${orig_args[@]}"; do
+  phys_arg=$(eval "echo $val")
+
+  # Extract the database type (e.g., llsm, rocksdb)
+  if [[ $phys_arg =~ --db=.+ ]]; then
+    db_type=${phys_arg:5}
+  fi
+
+  # Extract the checkpoint name, which shouldn't be passed as an argument further.
+  # Add anything else to args.
+  if [[ $phys_arg =~ --checkpoint_name=.+ ]]; then
+    checkpoint_name=${phys_arg:18}
+  else
+    all_args+=($phys_arg)
+  fi
+done
+
+if [[ -z $checkpoint_name ]]; then
+  echo >&2 "Usage: $0 --checkpoint_name=<checkpoint name> [other args passed to run_custom]"
   exit 1
 fi
 
-checkpoint_name=$1
-shift 1
-
-# Evaluates any environment variables in this script's arguments. This script
-# should only be run on trusted input.
-orig_args=$@
-all_args=()
-for val in "${orig_args[@]}"; do
-  all_args+=$(eval "echo $val")
-done
-
 # Generates the workload configuration and filters out unrelated arguments.
-args=$(python3 generate_workload.py $all_args)
+args=$(python3 generate_workload.py ${all_args[@]})
 
+echo "Detected DB Type: $db_type"
+echo "Detected checkpoint name: $checkpoint_name"
+
+# Add additional common arguments.
+args+=("--verbose")
+args+=("--db_path=$DB_PATH")
+args+=("--seed=$SEED")
+args+=("--notify_after_init")
+args+=("--skip_load")
+
+# Use the generated workload file.
+args+=("--workload_config=$COND_OUT/workload.yml")
+
+# Copy over the checkpoint.
 full_checkpoint_path=$DB_CHECKPOINT_PATH/$checkpoint_name
-
 rm -rf $DB_PATH
 cp -r $full_checkpoint_path $DB_PATH
 sync $DB_PATH
 
+init_finished=0
+
+function on_init_finish() {
+  init_finished=1
+}
+
+# Interrupt the first `wait` below when we receive a `SIGUSR1` signal.
+trap "on_init_finish" USR1
+
 set +e
-iostat -o JSON -d -y 1 > $COND_OUT/iostat.json &
+../../build/bench/run_custom ${args[@]} >$COND_OUT/results.csv &
+wait %1
+code=$?
+
+# The experiment failed before it finished initialization.
+if [ "$init_finished" -eq "0" ]; then
+  exit $code
+fi
+
+# The DB has finished initializing, so start `iostat`.
+iostat -o JSON -d -y 1 >$COND_OUT/iostat.json &
 iostat_pid=$!
 
-../../build/bench/run_custom \
-  --verbose \
-  --db_path=$DB_PATH \
-  --seed=$SEED \
-  --skip_load \
-  --workload_config=$COND_OUT/workload.yml \
-  $args \
-  > $COND_OUT/results.csv
+# Wait until the workload completes.
+wait %1
+code=$?
 
-cp $DB_PATH/llsm/LOG $COND_OUT/llsm.log
-cp $DB_PATH/rocksdb/LOG $COND_OUT/rocksdb.log
-
+# Stop `iostat`.
 kill -s SIGINT -- $iostat_pid
 wait
+
+cp $DB_PATH/$db_type/LOG $COND_OUT/$db_type.log
+du -b $DB_PATH >$COND_OUT/db_space.log
+
+# Report that the experiment failed if the `run_custom` exit code is not 0
+if [ $code -ne 0 ]; then
+  exit $code
+fi


### PR DESCRIPTION
This PR updates the R/W sweep experiment definitions. These experiments are meant to be run against `version-bufferpool`, so I'll cherry pick this commit over to that branch after merging into `master`. The `version-bufferpool` version of LLSM is supposed to emulate a disk-based B tree.

The main changes are:
- Use 16 application threads and 4 background threads
- Fill the pages up to 75%
- Enable bloom filters for RocksDB
- Add scans: 50% of the reads are scans (e.g., if 50% of the workload should be reads then 25% of the workload consists of point reads and 25% will consist of scans of lengths between 1 and 100)

We can also decrease the scan proportion if needed. I increased it to see if we can increase the performance difference between the tree and RocksDB, but it doesn't appear to have a significant effect.

![Zipfian 64B](https://user-images.githubusercontent.com/3946496/154113338-96ed3ca6-2066-4f0e-acf2-941d922029bb.png)