### PR TITLE
Create unique testing directories

### DIFF
--- a/tests/buffer_manager_test.cc
+++ b/tests/buffer_manager_test.cc
@@ -27,9 +27,9 @@ TEST(BufferManagerTest, CreateValues) {
 
 TEST(BufferManagerTest, WriteReadSequential) {
   const std::string dbname =
-      "/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-bufmgr-test";
+      "/tmp/llsm-bufmgr-test-" + std::to_string(std::time(nullptr));
   std::filesystem::remove_all(dbname);
-  std::filesystem::create_directories(dbname);
+  std::filesystem::create_directory(dbname);
 
   // Create data.
   KeyDistHints key_hints;
@@ -70,9 +70,9 @@ TEST(BufferManagerTest, WriteReadSequential) {
 
 TEST(BufferManagerTest, FlushDirty) {
   const std::string dbname =
-      "/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-bufmgr-test";
+      "/tmp/llsm-bufmgr-test-" + std::to_string(std::time(nullptr));
   std::filesystem::remove_all(dbname);
-  std::filesystem::create_directories(dbname);
+  std::filesystem::create_directory(dbname);
 
   // Create data.
   KeyDistHints key_hints;
@@ -122,10 +122,9 @@ TEST(BufferManagerTest, FlushDirty) {
 
 TEST(BufferManagerTest, Contains) {
   const std::string dbname =
-      "/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-bufmgr-test";
+      "/tmp/llsm-bufmgr-test-" + std::to_string(std::time(nullptr));
   std::filesystem::remove_all(dbname);
-  std::filesystem::create_directories(dbname);
-
+  std::filesystem::create_directory(dbname);
   // Create data.
   KeyDistHints key_hints;
   key_hints.record_size = 512;
@@ -171,9 +170,9 @@ TEST(BufferManagerTest, Contains) {
 
 TEST(BufferManagerTest, IncreaseNumPages) {
   const std::string dbname =
-      "/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-bufmgr-test";
+      "/tmp/llsm-bufmgr-test-" + std::to_string(std::time(nullptr));
   std::filesystem::remove_all(dbname);
-  std::filesystem::create_directories(dbname);
+  std::filesystem::create_directory(dbname);
 
   // Create data and model
   KeyDistHints key_hints;
@@ -225,9 +224,9 @@ TEST(BufferManagerTest, IncreaseNumPages) {
 
 TEST(BufferManagerTest, DecreaseNumPages) {
   const std::string dbname =
-      "/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-bufmgr-test";
+      "/tmp/llsm-bufmgr-test-" + std::to_string(std::time(nullptr));
   std::filesystem::remove_all(dbname);
-  std::filesystem::create_directories(dbname);
+  std::filesystem::create_directory(dbname);
 
   // Create data and model
   KeyDistHints key_hints;
@@ -289,9 +288,9 @@ TEST(BufferManagerTest, DecreaseNumPages) {
 
 TEST(BufferManagerTest, FixPageIfFrameAvailable) {
   const std::string dbname =
-      "/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-bufmgr-test";
+      "/tmp/llsm-bufmgr-test-" + std::to_string(std::time(nullptr));
   std::filesystem::remove_all(dbname);
-  std::filesystem::create_directories(dbname);
+  std::filesystem::create_directory(dbname);
 
   // Create buffer manager with 2 pages.
   BufMgrOptions bm_options;

--- a/tests/db_test.cc
+++ b/tests/db_test.cc
@@ -20,11 +20,10 @@ bool EqualTimespec(const timespec& lhs, const timespec& rhs) {
 
 class DBTest : public testing::Test {
  public:
-  DBTest()
-      : kDBDir("/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-test") {}
+  DBTest() : kDBDir("/tmp/llsm-test-" + std::to_string(std::time(nullptr))) {}
   void SetUp() override {
     std::filesystem::remove_all(kDBDir);
-    std::filesystem::create_directories(kDBDir);
+    std::filesystem::create_directory(kDBDir);
   }
   void TearDown() override { std::filesystem::remove_all(kDBDir); }
 

--- a/tests/file_manager_test.cc
+++ b/tests/file_manager_test.cc
@@ -18,9 +18,9 @@ using namespace llsm;
 
 TEST(FileManagerTest, FileConstruction) {
   const std::string dbpath =
-      "/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-filemgr-test";
+      "/tmp/llsm-filemgr-test-" + std::to_string(std::time(nullptr));
   std::filesystem::remove_all(dbpath);
-  std::filesystem::create_directories(dbpath);
+  std::filesystem::create_directory(dbpath);
 
   // Create data.
   KeyDistHints key_hints;
@@ -44,9 +44,9 @@ TEST(FileManagerTest, FileConstruction) {
 
 TEST(FileManagerTest, WriteReadSequential) {
   const std::string dbpath =
-      "/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-filemgr-test";
+      "/tmp/llsm-filemgr-test-" + std::to_string(std::time(nullptr));
   std::filesystem::remove_all(dbpath);
-  std::filesystem::create_directories(dbpath);
+  std::filesystem::create_directory(dbpath);
 
   // Create data.
   KeyDistHints key_hints;

--- a/tests/manifest_test.cc
+++ b/tests/manifest_test.cc
@@ -16,11 +16,11 @@ namespace fs = std::filesystem;
 class ManifestTest : public testing::Test {
  public:
   const fs::path kManifestFile =
-      "/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-test/MANIFEST";
+      "/tmp/llsm-test/MANIFEST-" + std::to_string(std::time(nullptr));
 
   void SetUp() override {
     fs::remove_all(kManifestFile.parent_path());
-    fs::create_directories(kManifestFile.parent_path());
+    fs::create_directory(kManifestFile.parent_path());
   }
 
   void TearDown() override { fs::remove_all(kManifestFile.parent_path()); }

--- a/tests/pg_db_test.cc
+++ b/tests/pg_db_test.cc
@@ -16,11 +16,10 @@ using namespace llsm::pg;
 class PGDBTest : public testing::Test {
  public:
   PGDBTest()
-      : kDBDir("/tmp/" + std::to_string(std::time(nullptr)) + "/pg-llsm-test") {
-  }
+      : kDBDir("/tmp/pg-llsm-test-" + std::to_string(std::time(nullptr))) {}
   void SetUp() override {
     std::filesystem::remove_all(kDBDir);
-    std::filesystem::create_directories(kDBDir);
+    std::filesystem::create_directory(kDBDir);
   }
   void TearDown() override { std::filesystem::remove_all(kDBDir); }
 

--- a/tests/pg_manager_rewrite_test.cc
+++ b/tests/pg_manager_rewrite_test.cc
@@ -20,11 +20,10 @@ using namespace llsm::pg;
 class PGManagerRewriteTest : public testing::Test {
  public:
   PGManagerRewriteTest()
-      : kDBDir("/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-pg-test") {
-  }
+      : kDBDir("/tmp/llsm-pg-test-" + std::to_string(std::time(nullptr))) {}
   void SetUp() override {
     std::filesystem::remove_all(kDBDir);
-    std::filesystem::create_directories(kDBDir);
+    std::filesystem::create_directory(kDBDir);
   }
   void TearDown() override { std::filesystem::remove_all(kDBDir); }
 

--- a/tests/pg_manager_test.cc
+++ b/tests/pg_manager_test.cc
@@ -20,11 +20,10 @@ namespace {
 class PGManagerTest : public testing::Test {
  public:
   PGManagerTest()
-      : kDBDir("/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-pg-test") {
-  }
+      : kDBDir("/tmp/llsm-pg-test-" + std::to_string(std::time(nullptr))) {}
   void SetUp() override {
     std::filesystem::remove_all(kDBDir);
-    std::filesystem::create_directories(kDBDir);
+    std::filesystem::create_directory(kDBDir);
   }
   void TearDown() override { std::filesystem::remove_all(kDBDir); }
 
@@ -616,7 +615,7 @@ TEST_F(PGManagerTest, PageBoundsConsistency) {
 
   // Check newly loaded DB that uses single-page segments only.
   std::filesystem::remove_all(kDBDir);
-  std::filesystem::create_directories(kDBDir);
+  std::filesystem::create_directory(kDBDir);
   options.use_segments = false;
   {
     Manager m = Manager::LoadIntoNew(kDBDir, dataset, options);

--- a/tests/wal_manager_test.cc
+++ b/tests/wal_manager_test.cc
@@ -16,11 +16,11 @@ namespace fs = std::filesystem;
 class WALManagerTest : public testing::Test {
  public:
   WALManagerTest()
-      : kWALDir("/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-wal") {}
+      : kWALDir("/tmp/llsm-wal-" + std::to_string(std::time(nullptr))) {}
 
   void SetUp() override {
     fs::remove_all(kWALDir);
-    fs::create_directories(kWALDir);
+    fs::create_directory(kWALDir);
   }
 
   void TearDown() override { fs::remove_all(kWALDir); }

--- a/tests/wal_rw_test.cc
+++ b/tests/wal_rw_test.cc
@@ -25,7 +25,7 @@ using namespace llsm;
 using namespace llsm::wal;
 
 const std::string kTestDir =
-    "/tmp/" + std::to_string(std::time(nullptr)) + "/llsm-test";
+    "/tmp/llsm-test-" + std::to_string(std::time(nullptr));
 const std::string kTestLogFile = kTestDir + "/test.wal";
 
 // Construct a string of the specified length made out of the supplied
@@ -52,7 +52,7 @@ class WALTest : public testing::Test {
   WALTest() : reading_(false), writer_(), reader_(), log_fd_(-1) {}
 
   void SetUp() override {
-    fs::create_directories(kTestDir);
+    fs::create_directory(kTestDir);
     writer_.reset(new Writer(kTestLogFile));
     reader_.reset(new Reader(kTestLogFile, &report_, /*checksum=*/true,
                              /*initial_offset=*/0));


### PR DESCRIPTION
Make temporary testing directories unique to avoid ownership clashes when running on the same filesystem.