### PR TITLE
Add custom inserts argument to run_custom

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -73,7 +73,7 @@ if(LLSM_BUILD_BENCHMARKS)
   FetchContent_Declare(
     ycsbr
     GIT_REPOSITORY git@github.com:mitdbg/ycsbr.git
-    GIT_TAG        v4.0.0
+    GIT_TAG        v4.1.0
   )
   FetchContent_MakeAvailable(ycsbr)
 


### PR DESCRIPTION
I updated YCSBR to work with custom insert traces to help support our insert forecasting work. The intended usage is as follows:

1. Set the insert distribution type as "custom" in the workload config and specify a unique name:
```yml
# ...

- num_requests: 10
  insert:
    proportion_pct: 100
    distribution:
      type: custom
      name: taxi

# ...
```

2. In `run_custom`, specify a map of trace names to text files that contain the keys to insert (e.g.,`--custom_inserts=taxi:path/to/taxi/trace.txt`)

See the corresponding YCSBR change here: https://github.com/mitdbg/ycsbr/commit/63f951d1faf57390b7f0995b642d1ed7a4fae528

cc @andreaskipf @mmarkakis 