### PR TITLE
Limit goal during forecasting to be no less than 2 * epsilon

### DIFF
--- a/page_grouping/manager_rewrite.cc
+++ b/page_grouping/manager_rewrite.cc
@@ -261,6 +261,10 @@ Status Manager::RewriteSegmentsImpl(
     future_goal = std::max(
         1UL, static_cast<size_t>(future_goal * current_num_keys_estimate /
                                  future_num_keys_estimate));
+    // If goal is less than 2 * epsilon, we can potentially get empty pages
+    // (i.e., pages that do not cover any keys in the key space).
+    future_goal =
+        std::max(static_cast<size_t>(2 * future_epsilon), future_goal);
   }
 
   //


### PR DESCRIPTION
This should prevent the creation of empty pages, which violates some assumptions in the page grouping code.