### PR TITLE
Adding dependencies for Ubuntu distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@
 An embedded key-value store for modern SSDs.
 
 ## Building from source
+
+### Install Dependencies
+
+A few packages that Treeline depends on are
+
+- `libtbb-dev`
+- `autoconf`
+- `libjemalloc-dev`
+
+On Ubuntu distribution the dependency installation command would look something like this
+
+```
+sudo apt-get install libtbb-dev autoconf libjemalloc-dev
+```
+
+Depending on the distro you have, ensure the above packages are installed. In case you do not
+find the above packages, run the CMake, and fix as and when it throws errors.
+
 CMake 3.17+ is required for building this project.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ A few packages that Treeline depends on are
 - `autoconf`
 - `libjemalloc-dev`
 
-On Ubuntu distribution the dependency installation command would look something like this
+Depending on the distribution you have, ensure the above packages are installed.
+On Ubuntu, you can install the dependencies using `apt`:
 
 ```
-sudo apt-get install libtbb-dev autoconf libjemalloc-dev
+sudo apt install libtbb-dev autoconf libjemalloc-dev
 ```
 
-Depending on the distro you have, ensure the above packages are installed. In case you do not
-find the above packages, run the CMake, and fix as and when it throws errors.
+TreeLine's other dependencies are fetched by CMake during compilation.
+
+### Compile
 
 CMake 3.17+ is required for building this project.
 


### PR DESCRIPTION
While I was trying to build TreeLine locally on my Ubuntu 20.04 distro, the mentioned CMake command failed due to missing packages. The packages that were missing but required for CMake to complete have been added to the README.md file.

It is definitely not an exhaustive list, given I might already have some packages pre-installed that are required by TreeLine, but thought of adding a few that I found missing.

Thank you for open-sourcing the implementation.